### PR TITLE
modify threshold

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,10 @@ ln -s /usr/share/munin/plugins/httping_ /etc/munin/plugins/httping_localhost
 [httping_localhost]
     env.URL	http://localhost/
     env.COUNT	5
-    env.connect_warning 0.400
-    env.connect_critical 0.700
-    env.processing_warning 0.400
-    env.processing_critical 1.000
+    env.connect_warning 400
+    env.connect_critical 700
+    env.processing_warning 400
+    env.processing_critical 1000
 ```
 
 ### plugin test

--- a/munin-node-conf.example
+++ b/munin-node-conf.example
@@ -2,10 +2,10 @@
 [httping_localhost]
     env.URL	http://pocketstudio.jp/
     env.COUNT	5
-    env.connect_warning 0.400
-    env.connect_critical 0.700
-    env.processing_warning 0.400
-    env.processing_critical 1.000
+    env.connect_warning 400
+    env.connect_critical 700
+    env.processing_warning 400
+    env.processing_critical 1000
 
 [httping_blog]
     env.URL	http://pocketstudio.jp/log3/


### PR DESCRIPTION
[先日のpull reqest](https://github.com/zembutsu/munin-plugin-httping_/pull/1)のアラート閾値の例がおかしかったので修正しました。
返ってくる値が`sec`ではなく`msec`なので、閾値の例を1000倍にしてます。
